### PR TITLE
fix: update nginx ssl ciphers to get TLSv1.2 working again

### DIFF
--- a/templates/nginx-zammad.conf.j2
+++ b/templates/nginx-zammad.conf.j2
@@ -27,7 +27,7 @@ server {
     ssl_certificate {{ zammad_ssl_cert_path }};
     ssl_certificate_key {{ zammad_ssl_key_path }};
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
     ssl_prefer_server_ciphers on;
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;


### PR DESCRIPTION
* Reference: https://cipherlist.eu/

* How to verify: 
   ```shell
   $ curl -I -v --tlsv1.2 --tls-max 1.2 https://example.org
   ```

